### PR TITLE
ci(gha): Configure CI and fix warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+      - release/**
+
+  pull_request:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install Rust Toolchain
+        run: rustup toolchain install stable --profile minimal --component clippy rustfmt --no-self-update
+
+      - name: Run Rustfmt
+        run: cargo fmt --all -- --check
+
+      - name: Run Clippy
+        run: cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings
+
+      - name: Check Docs
+        run: cargo doc --workspace --all-features --no-deps
+        env:
+          RUSTDOCFLAGS: -Dwarnings
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install Rust Toolchain
+        run: rustup toolchain install stable --profile minimal --no-self-update
+
+      - name: Run Cargo Tests
+        run: cargo test --workspace --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,12 +6,13 @@ keywords = ["json", "python", "nan", "infinity", "serde_json"]
 description = "A crate that adds a read adapter to deal with bad Python caused JSON payloads (NaNs and Infinities)"
 license = "BSD-3-Clause"
 homepage = "https://github.com/getsentry/rust-json-forensics"
-edition = "2018"
+edition = "2021"
 readme = "README.md"
 
 [dependencies]
+serde = { version = "1.0.82", optional = true }
 serde_json = { version = "1.0.33", optional = true }
-serde_self = { version = "1.0.82", optional = true, package = "serde" }
 
 [features]
-serde = ["serde_self", "serde_json"]
+default = []
+serde = ["dep:serde", "dep:serde_json"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,8 +74,8 @@ fn transition(bytes: &mut [u8], state: State, i: usize, c: u8) -> (State, u8) {
         (State::Infinity5, b't') => (State::Infinity6, b't'),
         (State::Infinity6, b'y') => {
             bytes[i - 7] = b'0';
-            for j in (i - 6)..i {
-                bytes[j] = b' ';
+            for b in &mut bytes[i - 6..i] {
+                *b = b' ';
             }
             (State::Initial, b' ')
         }
@@ -91,8 +91,8 @@ fn transition(bytes: &mut [u8], state: State, i: usize, c: u8) -> (State, u8) {
             if let Ok(num_str) = str::from_utf8(&bytes[start..i]) {
                 if num_str.parse::<u64>().is_err() && num_str.parse::<i64>().is_err() {
                     bytes[start] = b'0';
-                    for j in (start + 1)..i {
-                        bytes[j] = b' ';
+                    for b in &mut bytes[start + 1..i] {
+                        *b = b' ';
                     }
                 }
             }

--- a/src/serde_impl.rs
+++ b/src/serde_impl.rs
@@ -1,18 +1,4 @@
-use std::io;
-
-use serde_json;
-use serde_self::de;
-
-use crate::{translate_slice, JsonCompatRead};
-
-/// Deserialize an instance of type `T` from an IO stream of JSON.
-pub fn from_reader<R, T>(rdr: R) -> serde_json::Result<T>
-where
-    R: io::Read,
-    T: de::DeserializeOwned,
-{
-    serde_json::from_reader(JsonCompatRead::wrap(rdr))
-}
+use serde::de;
 
 /// Deserialize an instance of type `T` from bytes of JSON text.
 ///
@@ -22,7 +8,7 @@ pub fn from_slice<'a, T>(v: &'a mut [u8]) -> serde_json::Result<T>
 where
     T: de::Deserialize<'a>,
 {
-    translate_slice(v);
+    crate::translate_slice(v);
     serde_json::from_slice(v)
 }
 

--- a/src/serde_impl.rs
+++ b/src/serde_impl.rs
@@ -19,9 +19,9 @@ fn test_deserialize() {
     assert_eq!(
         rv,
         serde_json::Value::Array(vec![
-            serde_json::Value::Number(serde_json::Number::from_f64(0.0).unwrap()),
-            serde_json::Value::Number(serde_json::Number::from_f64(0.0).unwrap()),
-            serde_json::Value::Number(serde_json::Number::from_f64(0.0).unwrap()),
+            serde_json::Value::Number(serde_json::Number::from(0)),
+            serde_json::Value::Number(serde_json::Number::from_f64(-0.0).unwrap()),
+            serde_json::Value::Number(serde_json::Number::from(0)),
         ])
     );
 }


### PR DESCRIPTION
The crate did not compile with the `serde` feature since 39e8c1d0ea52fe81d4f7155f09ca12eec1ef3db1. The corresponding `from_read` function has now been removed. 

There was also an outdated test assertion that has been updated now.