### PR TITLE
fix(craft): Remove artifact provider for craft publish

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -3,6 +3,8 @@ github:
   owner: getsentry
   repo: rust-json-forensics
 changelogPolicy: none
+artifactProvider:
+  name: none
 targets:
   - name: github
   - name: crates

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,10 +15,11 @@ jobs:
     runs-on: ubuntu-latest
     name: "Release a new version"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           token: ${{ secrets.GH_RELEASE_PAT }}
           fetch-depth: 0
+
       - name: Prepare release
         uses: getsentry/action-prepare-release@v1
         env:


### PR DESCRIPTION
There are no artifacts. The default checks for artifacts in github, which fails.


