### PR TITLE
fix: replace owners-ingest with ingest

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @getsentry/owners-ingest
+* @getsentry/ingest


### PR DESCRIPTION
We are working with the Ingest team on consolidating the [owners-ingest team](https://github.com/orgs/getsentry/teams/owners-ingest) and [ingest team](https://github.com/orgs/getsentry/teams/ingest) in GitHub, owners-ingest will be deprecated.

Related PR in security-as-code: https://github.com/getsentry/security-as-code/pull/477